### PR TITLE
Added `BugReporter` to represent the author of an issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 ## Main Models
 
-- `BugReport`: in-memory report draft with `description`, `deviceInfo`, and screenshot `Data`.
+- `BugReport`: in-memory report draft with `description`, `reporter`, `deviceInfo`, and screenshot attachments.
+- `BugReporter`: reporter identity (`id`, `displayName`, optional `reachoutIdentifier`).
 - `DeviceInfo`: normalized device metadata captured at submit time.
 - `BugReportPackage`: packaged output ready for delivery (`payload` JSON + `attachments` persisted on disk).
 - `Bugger`: orchestrator that builds a `BugReport` (`draftReport`) and then packs/submits it (`submit`).
@@ -13,7 +14,7 @@ Supporting extension points:
 
 - `BugReportPacking` (default: `JSONReportPacker`)
 - `ReportSubmitting` (default: `NoopReportSubmitter`)
-- `DeviceInfoProviding` / `ScreenshotProviding`
+- `BugReporterProviding` / `DeviceInfoProviding` / `ScreenshotProviding`
 
 ## Demo App
 

--- a/Sources/Bugger/Infrastructure/BugReport.swift
+++ b/Sources/Bugger/Infrastructure/BugReport.swift
@@ -35,6 +35,7 @@ public struct BugReport: Codable, Sendable, Identifiable {
     public let id: UUID
     public let createdAt: Date
     public var description: String
+    public var reporter: BugReporter
     public var deviceInfo: DeviceInfo
     public var attachments: [BugReportAttachment]
 
@@ -42,12 +43,14 @@ public struct BugReport: Codable, Sendable, Identifiable {
         id: UUID = UUID(),
         createdAt: Date = Date(),
         description: String,
+        reporter: BugReporter = .unknown,
         deviceInfo: DeviceInfo,
         attachments: [BugReportAttachment] = []
     ) {
         self.id = id
         self.createdAt = createdAt
         self.description = description
+        self.reporter = reporter
         self.deviceInfo = deviceInfo
         self.attachments = attachments
     }
@@ -62,6 +65,7 @@ public struct BugReport: Codable, Sendable, Identifiable {
         id: UUID = UUID(),
         createdAt: Date = Date(),
         description: String,
+        reporter: BugReporter = .unknown,
         deviceInfo: DeviceInfo,
         screenshotData: [Data],
         screenshotMimeType: String
@@ -70,6 +74,7 @@ public struct BugReport: Codable, Sendable, Identifiable {
             id: id,
             createdAt: createdAt,
             description: description,
+            reporter: reporter,
             deviceInfo: deviceInfo,
             attachments: screenshotData.map {
                 BugReportAttachment.fromRawData($0, mimeType: screenshotMimeType)

--- a/Sources/Bugger/Infrastructure/BugReportPacking.swift
+++ b/Sources/Bugger/Infrastructure/BugReportPacking.swift
@@ -60,6 +60,8 @@ public struct BugReportJSONPayload: Codable, Sendable, Identifiable {
     }
 }
 
+// The in-memory representation of a bug report
+// to be sent off to the bug report service.
 public struct BugReportPackage: Sendable {
     public let reportID: UUID
     public let payload: Data
@@ -72,6 +74,9 @@ public struct BugReportPackage: Sendable {
     }
 }
 
+// Defines the responsibilities for packaging a BugReport
+// information to a `BugReportPackage`, the representation
+// of a bug report, ready to be sent out to a server.
 public protocol BugReportPacking: Sendable {
     func pack(_ report: BugReport) async throws -> BugReportPackage
 }

--- a/Sources/Bugger/Infrastructure/BugReportPacking.swift
+++ b/Sources/Bugger/Infrastructure/BugReportPacking.swift
@@ -39,6 +39,7 @@ public struct BugReportJSONPayload: Codable, Sendable, Identifiable {
     public let id: UUID
     public let createdAt: Date
     public let description: String
+    public let reporter: BugReporter
     public let deviceInfo: DeviceInfo
     public let attachments: [BugReportAttachmentReference]
 
@@ -46,12 +47,14 @@ public struct BugReportJSONPayload: Codable, Sendable, Identifiable {
         id: UUID,
         createdAt: Date,
         description: String,
+        reporter: BugReporter,
         deviceInfo: DeviceInfo,
         attachments: [BugReportAttachmentReference]
     ) {
         self.id = id
         self.createdAt = createdAt
         self.description = description
+        self.reporter = reporter
         self.deviceInfo = deviceInfo
         self.attachments = attachments
     }
@@ -115,6 +118,7 @@ public struct JSONReportPacker: BugReportPacking {
             id: report.id,
             createdAt: report.createdAt,
             description: report.description,
+            reporter: report.reporter,
             deviceInfo: report.deviceInfo,
             attachments: attachmentReferences
         )

--- a/Sources/Bugger/Infrastructure/BugReporter.swift
+++ b/Sources/Bugger/Infrastructure/BugReporter.swift
@@ -22,16 +22,4 @@ public struct BugReporter: Codable, Sendable {
             reachoutIdentifier: nil
         )
     }
-
-    public static func preview(
-        id: String = "preview-reporter",
-        displayName: String = "Preview Reporter",
-        reachoutIdentifier: String? = "preview@bugger.local"
-    ) -> Self {
-        Self(
-            id: id,
-            displayName: displayName,
-            reachoutIdentifier: reachoutIdentifier
-        )
-    }
 }

--- a/Sources/Bugger/Infrastructure/BugReporter.swift
+++ b/Sources/Bugger/Infrastructure/BugReporter.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+public struct BugReporter: Codable, Sendable {
+    public var id: String
+    public var displayName: String
+    public var reachoutIdentifier: String?
+
+    public init(
+        id: String,
+        displayName: String,
+        reachoutIdentifier: String? = nil
+    ) {
+        self.id = id
+        self.displayName = displayName
+        self.reachoutIdentifier = reachoutIdentifier
+    }
+
+    public static var unknown: Self {
+        Self(
+            id: "unknown-reporter",
+            displayName: "Unknown Reporter",
+            reachoutIdentifier: nil
+        )
+    }
+
+    public static func preview(
+        id: String = "preview-reporter",
+        displayName: String = "Preview Reporter",
+        reachoutIdentifier: String? = "preview@bugger.local"
+    ) -> Self {
+        Self(
+            id: id,
+            displayName: displayName,
+            reachoutIdentifier: reachoutIdentifier
+        )
+    }
+}

--- a/Sources/Bugger/Infrastructure/Bugger.swift
+++ b/Sources/Bugger/Infrastructure/Bugger.swift
@@ -63,15 +63,3 @@ public final class Bugger: Sendable {
         return package
     }
 }
-
-extension Bugger {
-    public static var preview: Self {
-        return Self(
-            bugReporterProvider: DefaultBugReporterProvider(),
-            deviceInfoProvider: DefaultDeviceInfoProvider(),
-            screenshotProvider: nil,
-            packer: JSONReportPacker(),
-            submitter: NoopReportSubmitter()
-        )
-    }
-}

--- a/Sources/Bugger/Infrastructure/Bugger.swift
+++ b/Sources/Bugger/Infrastructure/Bugger.swift
@@ -3,6 +3,7 @@ import Foundation
 /// Orchestrator for gathering information from all relevant providers
 /// and finally submit the information
 public final class Bugger: Sendable {
+    private let bugReporterProvider: BugReporterProviding
     private let deviceInfoProvider: DeviceInfoProviding
     private let screenshotProvider: ScreenshotProviding?
     private let packer: BugReportPacking
@@ -10,6 +11,7 @@ public final class Bugger: Sendable {
     
     public static var onDevice: Self {
         return Self(
+            bugReporterProvider: DefaultBugReporterProvider(),
             deviceInfoProvider: DefaultDeviceInfoProvider(),
             screenshotProvider: nil,
             packer: JSONReportPacker(),
@@ -18,11 +20,13 @@ public final class Bugger: Sendable {
     }
     
     public init(
+        bugReporterProvider: BugReporterProviding = DefaultBugReporterProvider(),
         deviceInfoProvider: DeviceInfoProviding,
         screenshotProvider: ScreenshotProviding?,
         packer: BugReportPacking,
         submitter: ReportSubmitting
     ) {
+        self.bugReporterProvider = bugReporterProvider
         self.deviceInfoProvider = deviceInfoProvider
         self.screenshotProvider = screenshotProvider
         self.packer = packer
@@ -33,6 +37,7 @@ public final class Bugger: Sendable {
         description: String,
         attachments: [BugReportAttachment] = []
     ) async throws -> BugReport {
+        let reporter = await bugReporterProvider.collect()
         let deviceInfo = await deviceInfoProvider.collect()
         let capturedAttachments: [BugReportAttachment]
 
@@ -45,6 +50,7 @@ public final class Bugger: Sendable {
         let allAttachments = attachments + capturedAttachments
         return BugReport(
             description: description,
+            reporter: reporter,
             deviceInfo: deviceInfo,
             attachments: allAttachments
         )
@@ -61,6 +67,7 @@ public final class Bugger: Sendable {
 extension Bugger {
     public static var preview: Self {
         return Self(
+            bugReporterProvider: DefaultBugReporterProvider(),
             deviceInfoProvider: DefaultDeviceInfoProvider(),
             screenshotProvider: nil,
             packer: JSONReportPacker(),

--- a/Sources/Bugger/Infrastructure/Mocks.swift
+++ b/Sources/Bugger/Infrastructure/Mocks.swift
@@ -1,0 +1,69 @@
+//
+//  Mocks.swift
+//  Bugger
+//
+//  Created by Fabio Milano on 2/18/26.
+//
+
+#if DEBUG && canImport(SwiftUI)
+
+extension Bugger {
+    public static var preview: Self {
+        return Self(
+            bugReporterProvider: DefaultBugReporterProvider(),
+            deviceInfoProvider: DefaultDeviceInfoProvider(),
+            screenshotProvider: nil,
+            packer: JSONReportPacker(),
+            submitter: NoopReportSubmitter()
+        )
+    }
+}
+
+extension BugReporter {
+    public static func preview(
+        id: String = "preview-reporter",
+        displayName: String = "Preview Reporter",
+        reachoutIdentifier: String? = "preview@bugger.local"
+    ) -> Self {
+        Self(
+            id: id,
+            displayName: displayName,
+            reachoutIdentifier: reachoutIdentifier
+        )
+    }
+}
+
+import UIKit
+extension BuggerScreenshotSource {
+    static var previewMock: BuggerScreenshotSource {
+        BuggerScreenshotSource(
+            mode: .manual,
+            addTitle: "Add Sample",
+            loadFromPicker: { _ in [] },
+            loadFromManual: {
+                await MainActor.run {
+                    [
+                        makeSample(color: .systemBlue),
+                        makeSample(color: .systemGreen),
+                        makeSample(color: .systemOrange)
+                    ].compactMap { data in
+                        guard let data else { return nil }
+                        return BugReportAttachment(data: data, mimeType: "image/png")
+                    }
+                }
+            }
+        )
+    }
+
+    private static func makeSample(color: UIColor) -> Data? {
+        let size = CGSize(width: 300, height: 600)
+        let renderer = UIGraphicsImageRenderer(size: size)
+        let image = renderer.image { context in
+            color.setFill()
+            context.fill(CGRect(origin: .zero, size: size))
+        }
+        return image.pngData()
+    }
+}
+
+#endif

--- a/Sources/Bugger/Infrastructure/Providers.swift
+++ b/Sources/Bugger/Infrastructure/Providers.swift
@@ -10,6 +10,11 @@ public protocol DeviceInfoProviding: Sendable {
     func collect() -> DeviceInfo
 }
 
+public protocol BugReporterProviding: Sendable {
+    @MainActor
+    func collect() -> BugReporter
+}
+
 public protocol ScreenshotProviding: Sendable {
     func capture() async throws -> [BugReportAttachment]
 }
@@ -29,6 +34,19 @@ public struct DefaultDeviceInfoProvider: DeviceInfoProviding {
             model: device.model,
             localizedModel: device.localizedModel,
             identifierForVendor: device.identifierForVendor?.uuidString
+        )
+    }
+}
+
+public struct DefaultBugReporterProvider: BugReporterProviding {
+    public init() {}
+
+    @MainActor public func collect() -> BugReporter {
+        let device = UIDevice.current
+        return BugReporter(
+            id: device.identifierForVendor?.uuidString ?? "unknown-reporter",
+            displayName: device.name,
+            reachoutIdentifier: nil
         )
     }
 }

--- a/Sources/Bugger/Infrastructure/Providers.swift
+++ b/Sources/Bugger/Infrastructure/Providers.swift
@@ -1,24 +1,34 @@
 import Foundation
 import UIKit
 
+// Defines the responsibilities to provide text attachment
+// like the description of what went wrong,
+// to a bug report.
 public protocol TextInfoProviding: Sendable {
     func collect() -> String
 }
 
+// Defines the responsibilities to provide device information
+// to attach to a bug report.
 public protocol DeviceInfoProviding: Sendable {
     @MainActor
     func collect() -> DeviceInfo
 }
 
+// Defines the responsibilities to provide information about
+// the author of a bug report.
 public protocol BugReporterProviding: Sendable {
     @MainActor
     func collect() -> BugReporter
 }
 
+// Defines the responsibilities to provide information about
+// screenshots attached to a bug report.
 public protocol ScreenshotProviding: Sendable {
     func capture() async throws -> [BugReportAttachment]
 }
 
+// Defines the responsibilities to submit a bug report.
 public protocol ReportSubmitting: Sendable {
     func submit(_ package: BugReportPackage) async throws
 }

--- a/Sources/Bugger/UI/BuggerScreenshotCarousel.swift
+++ b/Sources/Bugger/UI/BuggerScreenshotCarousel.swift
@@ -208,36 +208,6 @@ extension BuggerScreenshotSource {
             loadFromManual: { [] }
         )
     }
-
-    static var previewMock: BuggerScreenshotSource {
-        BuggerScreenshotSource(
-            mode: .manual,
-            addTitle: "Add Sample",
-            loadFromPicker: { _ in [] },
-            loadFromManual: {
-                await MainActor.run {
-                    [
-                        makeSample(color: .systemBlue),
-                        makeSample(color: .systemGreen),
-                        makeSample(color: .systemOrange)
-                    ].compactMap { data in
-                        guard let data else { return nil }
-                        return BugReportAttachment(data: data, mimeType: "image/png")
-                    }
-                }
-            }
-        )
-    }
-
-    private static func makeSample(color: UIColor) -> Data? {
-        let size = CGSize(width: 300, height: 600)
-        let renderer = UIGraphicsImageRenderer(size: size)
-        let image = renderer.image { context in
-            color.setFill()
-            context.fill(CGRect(origin: .zero, size: size))
-        }
-        return image.pngData()
-    }
 }
 
 struct BuggerScreenshotThumbnail: View {

--- a/Sources/Bugger/UI/BuggerScreenshotCarousel.swift
+++ b/Sources/Bugger/UI/BuggerScreenshotCarousel.swift
@@ -286,36 +286,6 @@ extension BuggerScreenshotSource {
             loadFromManual: { [] }
         )
     }
-
-    static var previewMock: BuggerScreenshotSource {
-        BuggerScreenshotSource(
-            mode: .manual,
-            addTitle: "Add Sample",
-            loadFromPicker: { _ in [] },
-            loadFromManual: {
-                await MainActor.run {
-                    [
-                        makeSample(color: .systemBlue),
-                        makeSample(color: .systemGreen),
-                        makeSample(color: .systemOrange)
-                    ].compactMap { data in
-                        guard let data else { return nil }
-                        return BugReportAttachment(data: data, mimeType: "image/png")
-                    }
-                }
-            }
-        )
-    }
-
-    private static func makeSample(color: UIColor) -> Data? {
-        let size = CGSize(width: 300, height: 600)
-        let renderer = UIGraphicsImageRenderer(size: size)
-        let image = renderer.image { context in
-            color.setFill()
-            context.fill(CGRect(origin: .zero, size: size))
-        }
-        return image.pngData()
-    }
 }
 
 struct BuggerScreenshotThumbnail: View {


### PR DESCRIPTION
# What

Added a new provider for a bug report that is responsible to collect the information about the author of the issue. The current implementation is simply defined to uniquely identify an author and optionally having a "reach out" identifier to follow up with them.

The `DefaultBugReporterProvider` provides a default implementation that inherits the information from the `BugDeviceInfoProvider` to uniquely identify the author of the issue.