### PR TITLE
New provider: Category

### DIFF
--- a/Demo/Demo/ContentView.swift
+++ b/Demo/Demo/ContentView.swift
@@ -51,7 +51,7 @@ struct ContentView: View {
             .safeAreaInset(edge: .bottom) {
                 Button {
                     activeSetup = DemoSetup(
-                        bugger: .onDevice,
+                        bugger: makeDemoBugger(),
                         includeScreenshots: providerOption.includeScreenshots,
                         showsOnDevicePackagePreview: true
                     )
@@ -106,6 +106,26 @@ private struct BuggerSheet: View {
         .sheet(item: $presentedPackage) { item in
             BugReportPackageSheet(package: item.package)
         }
+    }
+}
+
+private func makeDemoBugger() -> Bugger {
+    Bugger(
+        deviceInfoProvider: DefaultDeviceInfoProvider(),
+        screenshotProvider: nil,
+        categoriesProvider: DemoCategoriesProvider(),
+        packer: JSONReportPacker(),
+        submitter: NoopReportSubmitter()
+    )
+}
+
+private struct DemoCategoriesProvider: CategoriesProviding {
+    func fetchCategories() async throws -> [BugReportCategory] {
+        [
+            BugReportCategory(identifier: "ui", displayName: "UI"),
+            BugReportCategory(identifier: "performance", displayName: "Performance"),
+            BugReportCategory(identifier: "network", displayName: "Network")
+        ]
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Main Models
 
-- `BugReport`: in-memory report draft with `description`, `reporter`, `deviceInfo`, and screenshot attachments.
+- `BugReport`: in-memory report draft with `description`, `reporter`, `deviceInfo`, `categories` (`BugReportCategory`), and attachments.
 - `BugReporter`: reporter identity (`id`, `displayName`, optional `reachoutIdentifier`).
 - `DeviceInfo`: normalized device metadata captured at submit time.
 - `BugReportPackage`: packaged output ready for delivery (`payload` JSON + `attachments` persisted on disk).
@@ -14,7 +14,8 @@ Supporting extension points:
 
 - `BugReportPacking` (default: `JSONReportPacker`)
 - `ReportSubmitting` (default: `NoopReportSubmitter`)
-- `BugReporterProviding` / `DeviceInfoProviding` / `ScreenshotProviding`
+- `BugReporterProviding` / `DeviceInfoProviding` / `ScreenshotProviding` / `CategoriesProviding`
+- `BugReportCategory`: category type with `identifier` and `displayName`.
 
 ## Demo App
 

--- a/Sources/Bugger/Infrastructure/BugReport.swift
+++ b/Sources/Bugger/Infrastructure/BugReport.swift
@@ -38,6 +38,17 @@ public struct BugReport: Codable, Sendable, Identifiable {
     public var reporter: BugReporter
     public var deviceInfo: DeviceInfo
     public var attachments: [BugReportAttachment]
+    public var categories: [BugReportCategory]
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case createdAt
+        case description
+        case reporter
+        case deviceInfo
+        case attachments
+        case categories
+    }
 
     public init(
         id: UUID = UUID(),
@@ -45,7 +56,8 @@ public struct BugReport: Codable, Sendable, Identifiable {
         description: String,
         reporter: BugReporter = .unknown,
         deviceInfo: DeviceInfo,
-        attachments: [BugReportAttachment] = []
+        attachments: [BugReportAttachment] = [],
+        categories: [BugReportCategory] = []
     ) {
         self.id = id
         self.createdAt = createdAt
@@ -53,6 +65,29 @@ public struct BugReport: Codable, Sendable, Identifiable {
         self.reporter = reporter
         self.deviceInfo = deviceInfo
         self.attachments = attachments
+        self.categories = categories
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        description = try container.decode(String.self, forKey: .description)
+        reporter = try container.decode(BugReporter.self, forKey: .reporter)
+        deviceInfo = try container.decode(DeviceInfo.self, forKey: .deviceInfo)
+        attachments = try container.decode([BugReportAttachment].self, forKey: .attachments)
+        categories = try container.decodeIfPresent([BugReportCategory].self, forKey: .categories) ?? []
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(createdAt, forKey: .createdAt)
+        try container.encode(description, forKey: .description)
+        try container.encode(reporter, forKey: .reporter)
+        try container.encode(deviceInfo, forKey: .deviceInfo)
+        try container.encode(attachments, forKey: .attachments)
+        try container.encode(categories, forKey: .categories)
     }
 
     @available(*, deprecated, message: "Use attachments instead.")

--- a/Sources/Bugger/Infrastructure/BugReportCategory.swift
+++ b/Sources/Bugger/Infrastructure/BugReportCategory.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public struct BugReportCategory: Codable, Sendable, Hashable {
+    public let identifier: String
+    public let displayName: String
+
+    public init(identifier: String, displayName: String) {
+        self.identifier = identifier
+        self.displayName = displayName
+    }
+}

--- a/Sources/Bugger/Infrastructure/BugReportPacking.swift
+++ b/Sources/Bugger/Infrastructure/BugReportPacking.swift
@@ -41,6 +41,7 @@ public struct BugReportJSONPayload: Codable, Sendable, Identifiable {
     public let description: String
     public let reporter: BugReporter
     public let deviceInfo: DeviceInfo
+    public let categories: [BugReportCategory]
     public let attachments: [BugReportAttachmentReference]
 
     public init(
@@ -49,6 +50,7 @@ public struct BugReportJSONPayload: Codable, Sendable, Identifiable {
         description: String,
         reporter: BugReporter,
         deviceInfo: DeviceInfo,
+        categories: [BugReportCategory],
         attachments: [BugReportAttachmentReference]
     ) {
         self.id = id
@@ -56,6 +58,7 @@ public struct BugReportJSONPayload: Codable, Sendable, Identifiable {
         self.description = description
         self.reporter = reporter
         self.deviceInfo = deviceInfo
+        self.categories = categories
         self.attachments = attachments
     }
 }
@@ -125,6 +128,7 @@ public struct JSONReportPacker: BugReportPacking {
             description: report.description,
             reporter: report.reporter,
             deviceInfo: report.deviceInfo,
+            categories: report.categories,
             attachments: attachmentReferences
         )
 

--- a/Sources/Bugger/Infrastructure/Bugger.swift
+++ b/Sources/Bugger/Infrastructure/Bugger.swift
@@ -6,6 +6,7 @@ public final class Bugger: Sendable {
     private let bugReporterProvider: BugReporterProviding
     private let deviceInfoProvider: DeviceInfoProviding
     private let screenshotProvider: ScreenshotProviding?
+    private let categoriesProvider: CategoriesProviding?
     private let packer: BugReportPacking
     private let submitter: ReportSubmitting
     
@@ -14,6 +15,7 @@ public final class Bugger: Sendable {
             bugReporterProvider: DefaultBugReporterProvider(),
             deviceInfoProvider: DefaultDeviceInfoProvider(),
             screenshotProvider: nil,
+            categoriesProvider: nil,
             packer: JSONReportPacker(),
             submitter: NoopReportSubmitter()
         )
@@ -23,23 +25,27 @@ public final class Bugger: Sendable {
         bugReporterProvider: BugReporterProviding = DefaultBugReporterProvider(),
         deviceInfoProvider: DeviceInfoProviding,
         screenshotProvider: ScreenshotProviding?,
+        categoriesProvider: CategoriesProviding? = nil,
         packer: BugReportPacking,
         submitter: ReportSubmitting
     ) {
         self.bugReporterProvider = bugReporterProvider
         self.deviceInfoProvider = deviceInfoProvider
         self.screenshotProvider = screenshotProvider
+        self.categoriesProvider = categoriesProvider
         self.packer = packer
         self.submitter = submitter
     }
 
     public func draftReport(
         description: String,
-        attachments: [BugReportAttachment] = []
+        attachments: [BugReportAttachment] = [],
+        categories: [BugReportCategory]? = nil
     ) async throws -> BugReport {
         let reporter = await bugReporterProvider.collect()
         let deviceInfo = await deviceInfoProvider.collect()
         let capturedAttachments: [BugReportAttachment]
+        let selectedCategories: [BugReportCategory]
 
         if let screenshotProvider {
             capturedAttachments = try await screenshotProvider.capture()
@@ -47,13 +53,29 @@ public final class Bugger: Sendable {
             capturedAttachments = []
         }
 
+        if let categories {
+            selectedCategories = categories
+        } else if let categoriesProvider {
+            selectedCategories = try await categoriesProvider.fetchCategories()
+        } else {
+            selectedCategories = []
+        }
+
         let allAttachments = attachments + capturedAttachments
         return BugReport(
             description: description,
             reporter: reporter,
             deviceInfo: deviceInfo,
-            attachments: allAttachments
+            attachments: allAttachments,
+            categories: selectedCategories
         )
+    }
+
+    public func availableCategories() async throws -> [BugReportCategory] {
+        guard let categoriesProvider else {
+            return []
+        }
+        return try await categoriesProvider.fetchCategories()
     }
 
     @discardableResult

--- a/Sources/Bugger/Infrastructure/InfrastructureMocks.swift
+++ b/Sources/Bugger/Infrastructure/InfrastructureMocks.swift
@@ -1,0 +1,37 @@
+//
+//  Mocks.swift
+//  Bugger
+//
+//  Created by Fabio Milano on 2/18/26.
+//
+
+#if DEBUG && canImport(SwiftUI)
+
+extension Bugger {
+    public static var preview: Self {
+        return Self(
+            bugReporterProvider: DefaultBugReporterProvider(),
+            deviceInfoProvider: DefaultDeviceInfoProvider(),
+            screenshotProvider: nil,
+            categoriesProvider: nil,
+            packer: JSONReportPacker(),
+            submitter: NoopReportSubmitter()
+        )
+    }
+}
+
+extension BugReporter {
+    public static func preview(
+        id: String = "preview-reporter",
+        displayName: String = "Preview Reporter",
+        reachoutIdentifier: String? = "preview@bugger.local"
+    ) -> Self {
+        Self(
+            id: id,
+            displayName: displayName,
+            reachoutIdentifier: reachoutIdentifier
+        )
+    }
+}
+
+#endif

--- a/Sources/Bugger/Infrastructure/Providers.swift
+++ b/Sources/Bugger/Infrastructure/Providers.swift
@@ -28,6 +28,11 @@ public protocol ScreenshotProviding: Sendable {
     func capture() async throws -> [BugReportAttachment]
 }
 
+// Defines the responsibilities to provide report categories.
+public protocol CategoriesProviding: Sendable {
+    func fetchCategories() async throws -> [BugReportCategory]
+}
+
 // Defines the responsibilities to submit a bug report.
 public protocol ReportSubmitting: Sendable {
     func submit(_ package: BugReportPackage) async throws

--- a/Sources/Bugger/UI/BuggerReporterComposer.swift
+++ b/Sources/Bugger/UI/BuggerReporterComposer.swift
@@ -10,10 +10,17 @@ import SwiftUI
 struct BuggerReporterComposer: View {
     @Bindable
     var viewModel: BuggerReporterComposerViewModel
+    let categoriesViewModel: BuggerCategorySelectionViewModel?
 
     var body: some View {
         TextEditor(text: $viewModel.text)
             .frame(minHeight: 120, maxHeight: 200)
+            .padding(.bottom, 28)
+            .overlay(alignment: .bottomTrailing) {
+                if let categoriesViewModel {
+                    BuggerComposerCategoryButton(viewModel: categoriesViewModel)
+                }
+            }
     }
 }
 
@@ -29,5 +36,122 @@ final class BuggerReporterComposerViewModel: BuggerReportProviding, SectionTitle
         var draft = draft
         draft.description = text
         return draft
+    }
+}
+
+private struct BuggerComposerCategoryButton: View {
+    @Bindable var viewModel: BuggerCategorySelectionViewModel
+
+    private var selectedCategoryName: String? {
+        guard let selectedID = viewModel.selectedCategoryIdentifier else { return nil }
+        return viewModel.categories.first(where: { $0.identifier == selectedID })?.displayName
+    }
+
+    var body: some View {
+        if viewModel.hasAvailableCategories {
+            Menu {
+                Button("No category") {
+                    viewModel.selectedCategoryIdentifier = nil
+                }
+                ForEach(viewModel.categories, id: \.identifier) { category in
+                    Button(category.displayName) {
+                        viewModel.selectedCategoryIdentifier = category.identifier
+                    }
+                }
+            } label: {
+                HStack(spacing: 4) {
+                    Text(selectedCategoryName ?? "No category")
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.caption2)
+                }
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(
+                    Capsule(style: .continuous)
+                        .fill(Color(uiColor: .tertiarySystemFill))
+                )
+            }
+        }
+    }
+}
+
+
+@Observable
+@MainActor
+final class BuggerCategorySelectionViewModel: BuggerReportProviding {
+    private let bugger: Bugger
+    private var loadTask: Task<[BugReportCategory], Never>?
+
+    private(set) var categories: [BugReportCategory] = []
+    var selectedCategoryIdentifier: String? = nil
+
+    init(bugger: Bugger) {
+        self.bugger = bugger
+    }
+
+    init(
+        previewCategories: [BugReportCategory],
+        selectedCategoryIdentifier: String? = nil
+    ) {
+        self.bugger = .onDevice
+        self.categories = previewCategories
+        self.selectedCategoryIdentifier = selectedCategoryIdentifier
+        self.loadTask = Task { previewCategories }
+    }
+
+    var hasAvailableCategories: Bool {
+        !categories.isEmpty
+    }
+
+    func loadIfNeeded() async {
+        if loadTask == nil {
+            loadTask = Task { [bugger] in
+                do {
+                    return try await bugger.availableCategories()
+                } catch {
+                    return []
+                }
+            }
+        }
+
+        if let loadedCategories = await loadTask?.value {
+            categories = loadedCategories
+            if let selectedCategoryIdentifier,
+               !categories.contains(where: { $0.identifier == selectedCategoryIdentifier }) {
+                self.selectedCategoryIdentifier = nil
+            }
+        }
+    }
+
+    func apply(to draft: BuggerReportDraft) async throws -> BuggerReportDraft {
+        var draft = draft
+        if let selectedCategoryIdentifier,
+           let category = categories.first(where: { $0.identifier == selectedCategoryIdentifier }) {
+            draft.categories = [category]
+        } else {
+            draft.categories = []
+        }
+        return draft
+    }
+}
+
+#Preview("Composer") {
+    let composer = BuggerReporterComposerViewModel()
+    composer.text = """
+    Steps to reproduce:
+    1. Open Settings
+    2. Tap Save
+    3. Observe freeze
+    """
+
+    return Form {
+        Section(composer.sectionTitle) {
+            BuggerReporterComposer(
+                viewModel: composer,
+                categoriesViewModel: .previewMock
+            )
+        }
     }
 }

--- a/Sources/Bugger/UI/UIMocks.swift
+++ b/Sources/Bugger/UI/UIMocks.swift
@@ -7,32 +7,6 @@
 
 #if DEBUG && canImport(SwiftUI)
 
-extension Bugger {
-    public static var preview: Self {
-        return Self(
-            bugReporterProvider: DefaultBugReporterProvider(),
-            deviceInfoProvider: DefaultDeviceInfoProvider(),
-            screenshotProvider: nil,
-            packer: JSONReportPacker(),
-            submitter: NoopReportSubmitter()
-        )
-    }
-}
-
-extension BugReporter {
-    public static func preview(
-        id: String = "preview-reporter",
-        displayName: String = "Preview Reporter",
-        reachoutIdentifier: String? = "preview@bugger.local"
-    ) -> Self {
-        Self(
-            id: id,
-            displayName: displayName,
-            reachoutIdentifier: reachoutIdentifier
-        )
-    }
-}
-
 import UIKit
 extension BuggerScreenshotSource {
     static var previewMock: BuggerScreenshotSource {
@@ -63,6 +37,19 @@ extension BuggerScreenshotSource {
             context.fill(CGRect(origin: .zero, size: size))
         }
         return image.pngData()
+    }
+}
+
+extension BuggerCategorySelectionViewModel {
+    static var previewMock: BuggerCategorySelectionViewModel {
+        BuggerCategorySelectionViewModel(
+            previewCategories: [
+                BugReportCategory(identifier: "ui", displayName: "UI"),
+                BugReportCategory(identifier: "performance", displayName: "Performance"),
+                BugReportCategory(identifier: "network", displayName: "Network")
+            ],
+            selectedCategoryIdentifier: nil
+        )
     }
 }
 


### PR DESCRIPTION
# What

A new provider responsible to return an arbitrary collection of categories that can be selecting when composing a new bug report. This can become useful when the reporter wants to provide more information on the type of issue they are reporting on like "feature request", "bug", "crash".

# How

This provider follows the same structure as all the other provider but to allow more flexibility, it is built with asynchronous execution in mind to allow categories to be return.

<table>
  <tr>
    <td width="50%">
      <img src="https://github.com/user-attachments/assets/49b0d0a9-eca4-4228-a4a0-86174dd01b3d" alt="Screenshot 1" width="100%" />
    </td>
    <td width="50%">
      <img src="https://github.com/user-attachments/assets/9438058d-7339-4acf-821f-24b5b3913ab4" alt="Screenshot 2" width="100%" />
    </td>
  </tr>
</table>

